### PR TITLE
fix a bug when sending image to openai

### DIFF
--- a/modules/llm/chat.py
+++ b/modules/llm/chat.py
@@ -90,7 +90,7 @@ class LLMMessage(BaseModel):
         content = [{"type": "text", "text": self.text}]
 
         if self.image:
-            content.insert(0, {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{self.text}"}})
+            content.insert(0, {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{self.image}"}})
 
         return {
             "role": self.role,


### PR DESCRIPTION
The initial code incorrectly utilized self.text instead of self.image, leading to errors when transmitting images to the OpenAI API.