### PR TITLE
do not overwrite "sams" in "folder_paths" if it is present

### DIFF
--- a/modules/inpaint/sam/nodes.py
+++ b/modules/inpaint/sam/nodes.py
@@ -9,12 +9,13 @@ import comfy.utils
 
 from ...utils import ensure_package, tensor2pil, pil2tensor
 
-folder_paths.folder_names_and_paths["sams"] = (
-    [
-        os.path.join(folder_paths.models_dir, "sams"),
-    ],
-    folder_paths.supported_pt_extensions,
-)
+if "sams" not in folder_paths.folder_names_and_paths:
+    folder_paths.folder_names_and_paths["sams"] = (
+        [
+            os.path.join(folder_paths.models_dir, "sams"),
+        ],
+        folder_paths.supported_pt_extensions,
+    )
 
 gpu = model_management.get_torch_device()
 cpu = torch.device("cpu")


### PR DESCRIPTION
Without this small change, this node overwrites the `sams` value set by the `extra_model_paths.yaml` config, which is not very good.

A simple check to see if such an entry exists solves the problem.