### PR TITLE
Feature: Load muti_image for LLMMessageNode

### DIFF
--- a/modules/llm/chat.py
+++ b/modules/llm/chat.py
@@ -490,7 +490,7 @@ class LLMMessageNode:
     FUNCTION = "make_message"
     CATEGORY = "ArtVenture/LLM"
 
-    def make_message(self, role, text, image = None, messages: Optional[List[LLMMessage]] = None):
+    def make_message(self, role, text, image: Optional[Tensor] = None, messages: Optional[List[LLMMessage]] = None):
         messages = [] if messages is None else messages.copy()
         
         if role == "system":

--- a/modules/llm/chat.py
+++ b/modules/llm/chat.py
@@ -84,14 +84,15 @@ class LLMMessageRole(str, Enum):
 class LLMMessage(BaseModel):
     role: LLMMessageRole = LLMMessageRole.user
     text: str
-    image: Optional[str] = None  # base64 enoded image
+    image: Optional[List[str]] = None  # base64 enoded image
 
     def to_openai_message(self):
         content = [{"type": "text", "text": self.text}]
 
         if self.image:
-            content.insert(0, {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{self.text}"}})
-
+            for image in self.image:
+                content.append({"type": "image_url", "image_url": {"url": f"data:image/png;base64,{image}"}})
+            
         return {
             "role": self.role,
             "content": content,
@@ -489,9 +490,9 @@ class LLMMessageNode:
     FUNCTION = "make_message"
     CATEGORY = "ArtVenture/LLM"
 
-    def make_message(self, role, text, image: Optional[Tensor] = None, messages: Optional[List[LLMMessage]] = None):
+    def make_message(self, role, text, image = None, messages: Optional[List[LLMMessage]] = None):
         messages = [] if messages is None else messages.copy()
-
+        
         if role == "system":
             if isinstance(image, Tensor):
                 raise Exception("System prompt does not support image.")
@@ -501,8 +502,8 @@ class LLMMessageNode:
                 raise Exception("Only one system prompt is allowed.")
 
         if isinstance(image, Tensor):
-            pil = tensor2pil(image)
-            content = pil2base64(pil)
+            pil = tensor2pil(image)            
+            content = [pil2base64(img) for img in pil]
             messages.append(LLMMessage(role=role, text=text, image=content))
         else:
             messages.append(LLMMessage(role=role, text=text))

--- a/modules/utility_nodes.py
+++ b/modules/utility_nodes.py
@@ -9,6 +9,7 @@ from typing import List, Dict, Tuple
 
 from PIL import Image, ImageOps, ImageFilter
 import numpy as np
+import re
 
 import folder_paths
 import comfy.utils
@@ -152,6 +153,7 @@ def load_images_from_url(urls: List[str], keep_alpha_channel=False):
     return (images, masks)
 
 
+
 class UtilLoadImageFromUrl:
     def __init__(self) -> None:
         self.output_dir = folder_paths.get_temp_directory()
@@ -172,6 +174,17 @@ class UtilLoadImageFromUrl:
                     {"default": False, "label_on": "list", "label_off": "batch"},
                 ),
                 "url": ("STRING", {"default": "", "multiline": True, "dynamicPrompts": False}),
+                "resize": (
+                    "BOOLEAN",
+                    {"default": False, "label_on": "enabled", "label_off": "disabled"}
+                ),
+                "resize_image": ("INT", {
+                    "default": 512,  # default resize value
+                    "min": 64,  
+                    "max": 2048,  
+                    "step": 64,  # step size
+                    "display": "number"
+                }),
             },
         }
 
@@ -181,12 +194,19 @@ class UtilLoadImageFromUrl:
     CATEGORY = "Art Venture/Image"
     FUNCTION = "load_image"
 
-    def load_image(self, image="", keep_alpha_channel=False, output_mode=False, url=""):
+    def load_image(self, image="", keep_alpha_channel=False, output_mode=False, url="", resize=False, resize_image=512):
         if not image or image == "":
             image = url
 
-        urls = image.strip().split("\n")
+        # Split the string on both newline "\n" and comma ","
+        urls = re.split(r'[,\n]', image.strip())
+
+        # Remove any empty strings from the resulting list
+        urls = [url for url in urls if url]
+        
+        # Get images and maske from urls
         images, masks = load_images_from_url(urls, keep_alpha_channel)
+
         if len(images) == 0:
             image = torch.zeros((1, 64, 64, 3), dtype=torch.float32, device="cpu")
             mask = torch.zeros((64, 64), dtype=torch.float32, device="cpu")
@@ -198,6 +218,15 @@ class UtilLoadImageFromUrl:
         np_masks = []
 
         for image, mask in zip(images, masks):
+            # Resize image if resize is enabled
+            if resize:
+                image = image.resize((resize_image, resize_image))
+                if mask is not None:
+                    mask = mask.resize((resize_image, resize_image))
+
+            # Ensure all images are RGB (3 channels)
+            image = image.convert("RGB") 
+
             if mask is not None:
                 preview_image = Image.new("RGB", image.size)
                 preview_image.paste(image, (0, 0))
@@ -212,7 +241,7 @@ class UtilLoadImageFromUrl:
                 mask = np.array(mask).astype(np.float32) / 255.0
                 mask = 1.0 - torch.from_numpy(mask)
             else:
-                mask = torch.zeros((64, 64), dtype=torch.float32, device="cpu")
+                mask = torch.zeros((resize_image, resize_image), dtype=torch.float32, device="cpu")
 
             np_images.append(image)
             np_masks.append(mask.unsqueeze(0))
@@ -228,11 +257,17 @@ class UtilLoadImageFromUrl:
                         break
 
             if has_size_mismatch:
-                raise Exception("To output as batch, images must have the same size. Use list output mode instead.")
+                raise Exception(
+                    "To output as batch, all images must have the same size. "
+                    "If you want to use batch mode, please enable the 'resize' option "
+                    "and specify a resize value to ensure all images are the same size."
+                )
 
             result = ([torch.cat(np_images)], [torch.cat(np_masks)], True)
 
         return {"ui": {"images": previews}, "result": result}
+
+
 
 
 class UtilLoadImageAsMaskFromUrl(UtilLoadImageFromUrl):

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -169,7 +169,14 @@ def pil2tensor(image: Image.Image):
 
 
 def tensor2pil(image: torch.Tensor, mode=None):
-    return numpy2pil(image.cpu().numpy().squeeze(), mode=mode)
+    if image.ndimension() == 4:  # (batch_size, channels, height, width)
+        pil_images = []
+        for i in range(image.size(0)):
+            pil_image = numpy2pil(image[i].cpu().numpy().squeeze(), mode=mode)
+            pil_images.append(pil_image)
+        return pil_images
+    else:
+        return numpy2pil(image.cpu().numpy().squeeze(), mode=mode)
 
 
 def tensor2bytes(image: torch.Tensor) -> bytes:


### PR DESCRIPTION
## Updated:
### - Update muti image input for LLMMessageNode
#### before:
![image](https://github.com/user-attachments/assets/8fa4e632-6e5b-4488-a0c2-bae9778e89c3)
#### after:
![image](https://github.com/user-attachments/assets/89feecb8-896b-4539-a300-57b19a1f6298)

### - Support both list url: "," and "\n"
![image](https://github.com/user-attachments/assets/0ce96a54-7c7f-43e3-8107-e943908bc468)
![image](https://github.com/user-attachments/assets/5cdaa1ad-6979-4985-ab8f-a876478f9fda)
