### PR TITLE
Fixed image not sent to LLM when using LLM Message node due to sending the text instead of the base64 image

### DIFF
--- a/modules/llm/chat.py
+++ b/modules/llm/chat.py
@@ -90,7 +90,7 @@ class LLMMessage(BaseModel):
         content = [{"type": "text", "text": self.text}]
 
         if self.image:
-            content.insert(0, {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{self.text}"}})
+            content.insert(0, {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{self.image}"}})
 
         return {
             "role": self.role,


### PR DESCRIPTION
It seems that in the `LLMMessage` class, we accidentally pass the `self.text` instead of `self.image` when an image is used in the node.
This causes the API exception as we pass the text of the LLM instead of the formatted base64 image. 

#94 